### PR TITLE
refactor: add searchTerm as base state in app for search keyword

### DIFF
--- a/src/components/App.js
+++ b/src/components/App.js
@@ -4,20 +4,18 @@ import youtube from '../apis/youtube';
 import VideoList from './VideoList';
 import VideoDetail from './VideoDetail';
 class App extends Component {
-  state = { videos: [], selectedVideo: null };
+  state = {
+    searchTerm: 'coding music',
+    videos: [],
+    selectedVideo: null
+  };
 
-  onTermSubmit = async term => {
-    const response = await youtube
-      .get('/search', {
-        params: {
-          q: term
-        }
-      })
-      .catch(e => console.log('API Failed ', e));
+  onFormSubmit = searchTerm => {
     this.setState({
-      videos: response.data.items,
-      selectedVideo: response.data.items[0]
-    });
+      ...this.state,
+      searchTerm
+    })
+    this.submitSearch(searchTerm)
   };
 
   onVideoSelect = video => {
@@ -25,15 +23,32 @@ class App extends Component {
     this.setState({ selectedVideo: video });
   };
 
-  componentDidMount() {
-    this.onTermSubmit('coding music');
+  submitSearch = async (searchTerm) => {
+    try {
+      const response = await youtube
+        .get('/search', {
+          params: {
+            q: searchTerm
+          }
+        })
+      this.setState({
+        videos: response.data.items,
+        selectedVideo: response.data.items[0]
+      });
+    } catch (e) {
+      console.log('API Failed ', e)
+    }
+  }
+
+  componentDidMount () {
+    this.submitSearch()
   }
 
   render() {
     return (
       <div className="ui container">
         <div className="ui row">
-          <SearchBar onFormSubmit={this.onTermSubmit} />
+          <SearchBar term={ this.state.searchTerm } onFormSubmit={this.onFormSubmit} />
 
           <div className="eleven wide column">
             <VideoDetail video={this.state.selectedVideo} />

--- a/src/components/App.js
+++ b/src/components/App.js
@@ -41,7 +41,7 @@ class App extends Component {
   }
 
   componentDidMount () {
-    this.submitSearch()
+    this.submitSearch(this.state.searchTerm)
   }
 
   render() {

--- a/src/components/SearchBar.js
+++ b/src/components/SearchBar.js
@@ -1,7 +1,7 @@
 import React, { Component } from 'react';
 class SearchBar extends Component {
   state = {
-    term: ''
+    term: this.props.term || ''
   };
   onInputChange = e => {
     this.setState({ term: e.target.value });


### PR DESCRIPTION
# Suggestion

Currently there's a minor UX issue that the search is automatically showing result of "coding music", but the searchbar shows nothing.

Since the parent App.js able to trigger the initial search without the search bar, then it would be better if the search keyword is owned by the App state so it has control over the expected search keyword.

Also, this opens the possibility to enable search keyword by default from URL parameter, and let the App.js to handle it.