### PR TITLE
fix(video): missing key on loop VideoItem

### DIFF
--- a/src/components/VideoList.js
+++ b/src/components/VideoList.js
@@ -4,15 +4,18 @@ import VideoItem from './VideoItem';
 const VideoList = ({ videos, onVideoSelect }) => {
   // has props.videos
 
-  const renderedList = videos.map(video => {
-    return (
-      <VideoItem
-        key={video.id.videoId}
-        video={video}
-        onVideoSelect={onVideoSelect}
-      />
-    );
-  });
+  const renderedList = videos
+    // some video data are a "channel", so it can't be rendered as video
+    .filter(video => video.id && video.id.videoId)
+    .map(video => {
+      return (
+        <VideoItem
+          key={video.id.videoId}
+          video={video}
+          onVideoSelect={onVideoSelect}
+        />
+      );
+    });
   return <div className="ui relaxed divided list">{renderedList}</div>;
 };
 export default VideoList;


### PR DESCRIPTION
# Issue

Some video items rendered can be a channel, and when it's clicked, it will not be playable in the video player.

# Changes

- some video data returned is a channel, so it has no id.videoId
- map the videos to only allow video with videoId